### PR TITLE
[fix] better support of primitive in jsonrpc parameters (double for e…

### DIFF
--- a/fusion-json/src/main/java/io/yupiik/fusion/json/internal/JsonMapperImpl.java
+++ b/fusion-json/src/main/java/io/yupiik/fusion/json/internal/JsonMapperImpl.java
@@ -23,6 +23,7 @@ import io.yupiik.fusion.json.internal.codec.BooleanJsonCodec;
 import io.yupiik.fusion.json.internal.codec.CollectionJsonCodec;
 import io.yupiik.fusion.json.internal.codec.DoubleJsonCodec;
 import io.yupiik.fusion.json.internal.codec.EnumJsonCodec;
+import io.yupiik.fusion.json.internal.codec.FloatJsonCodec;
 import io.yupiik.fusion.json.internal.codec.IntegerJsonCodec;
 import io.yupiik.fusion.json.internal.codec.LocalDateJsonCodec;
 import io.yupiik.fusion.json.internal.codec.LocalDateTimeJsonCodec;
@@ -93,6 +94,11 @@ public class JsonMapperImpl implements JsonMapper {
         this.codecs = new ConcurrentHashMap<>();
         this.codecs.putAll(toCodecMap(jsonCodecs.stream()));
         this.codecs.putAll(toCodecMap(builtInCodecs().filter(it -> !this.codecs.containsKey(it.type()))));
+        this.codecs.putIfAbsent(double.class, this.codecs.get(Double.class));
+        this.codecs.putIfAbsent(float.class, this.codecs.get(Float.class));
+        this.codecs.putIfAbsent(int.class, this.codecs.get(Integer.class));
+        this.codecs.putIfAbsent(long.class, this.codecs.get(Long.class));
+        this.codecs.putIfAbsent(boolean.class, this.codecs.get(Boolean.class));
         if (!this.codecs.containsKey(Map.class)) {
             final var object = this.codecs.get(Object.class);
             if (object != null) {
@@ -107,6 +113,7 @@ public class JsonMapperImpl implements JsonMapper {
                 new IntegerJsonCodec(),
                 new LongJsonCodec(),
                 new DoubleJsonCodec(),
+                new FloatJsonCodec(),
                 new BigDecimalJsonCodec(),
                 new BooleanJsonCodec(),
                 new LocalDateJsonCodec(),

--- a/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/DoubleJsonCodec.java
+++ b/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/DoubleJsonCodec.java
@@ -17,6 +17,8 @@ package io.yupiik.fusion.json.internal.codec;
 
 import io.yupiik.fusion.json.spi.Parser;
 
+import java.math.BigDecimal;
+
 public class DoubleJsonCodec extends NumberJsonCodec<Double> {
     public DoubleJsonCodec() {
         super(Double.class);
@@ -25,5 +27,10 @@ public class DoubleJsonCodec extends NumberJsonCodec<Double> {
     @Override
     protected Double read(final Parser parser) {
         return parser.getDouble();
+    }
+
+    @Override
+    protected Double mapBigDecimal(final BigDecimal bigDecimal) {
+        return bigDecimal.doubleValue();
     }
 }

--- a/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/FloatJsonCodec.java
+++ b/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/FloatJsonCodec.java
@@ -19,18 +19,18 @@ import io.yupiik.fusion.json.spi.Parser;
 
 import java.math.BigDecimal;
 
-public class IntegerJsonCodec extends NumberJsonCodec<Integer> {
-    public IntegerJsonCodec() {
-        super(Integer.class);
+public class FloatJsonCodec extends NumberJsonCodec<Float> {
+    public FloatJsonCodec() {
+        super(Float.class);
     }
 
     @Override
-    protected Integer read(final Parser parser) {
-        return parser.getInt();
+    protected Float read(final Parser parser) {
+        return (float) parser.getDouble();
     }
 
     @Override
-    protected Integer mapBigDecimal(final BigDecimal bigDecimal) {
-        return bigDecimal.intValue();
+    protected Float mapBigDecimal(final BigDecimal bigDecimal) {
+        return bigDecimal.floatValue();
     }
 }

--- a/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/LongJsonCodec.java
+++ b/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/LongJsonCodec.java
@@ -17,6 +17,8 @@ package io.yupiik.fusion.json.internal.codec;
 
 import io.yupiik.fusion.json.spi.Parser;
 
+import java.math.BigDecimal;
+
 public class LongJsonCodec extends NumberJsonCodec<Long> {
     public LongJsonCodec() {
         super(Long.class);
@@ -25,5 +27,10 @@ public class LongJsonCodec extends NumberJsonCodec<Long> {
     @Override
     protected Long read(final Parser parser) {
         return parser.getLong();
+    }
+
+    @Override
+    protected Long mapBigDecimal(final BigDecimal bigDecimal) {
+        return bigDecimal.longValue();
     }
 }

--- a/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/NumberJsonCodec.java
+++ b/fusion-json/src/main/java/io/yupiik/fusion/json/internal/codec/NumberJsonCodec.java
@@ -21,8 +21,10 @@ import io.yupiik.fusion.json.spi.Parser;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 
 import static io.yupiik.fusion.json.spi.Parser.Event.VALUE_NUMBER;
+import static io.yupiik.fusion.json.spi.Parser.Event.VALUE_STRING;
 
 public abstract class NumberJsonCodec<A> implements JsonCodec<A> {
     private final Class<A> type;
@@ -32,6 +34,8 @@ public abstract class NumberJsonCodec<A> implements JsonCodec<A> {
     }
 
     protected abstract A read(final Parser parser);
+
+    protected abstract A mapBigDecimal(BigDecimal bigDecimal);
 
     @Override
     public Type type() {
@@ -46,6 +50,9 @@ public abstract class NumberJsonCodec<A> implements JsonCodec<A> {
         }
         final JsonParser.Event event = parser.next();
         if (event != VALUE_NUMBER) {
+            if (event == VALUE_STRING) { // assume it was a BigDecimal serialized so try to deserialize it
+                return mapBigDecimal(new BigDecimal(parser.getString()));
+            }
             throw new IllegalStateException("Expected VALUE_NUMBER but got: " + event);
         }
         return read(parser);

--- a/fusion-processor/src/main/java/io/yupiik/fusion/framework/processor/internal/generator/BaseHttpEndpointGenerator.java
+++ b/fusion-processor/src/main/java/io/yupiik/fusion/framework/processor/internal/generator/BaseHttpEndpointGenerator.java
@@ -169,12 +169,16 @@ public abstract class BaseHttpEndpointGenerator extends BaseGenerator {
                     int.class.getName().equals(param.className()) ||
                     long.class.getName().equals(param.className()) ||
                     boolean.class.getName().equals(param.className()) ||
+                    double.class.getName().equals(param.className()) ||
+                    float.class.getName().equals(param.className()) ||
                     String.class.getName().equals(param.className()) ||
                     OffsetDateTime.class.getName().equals(param.className()) ||
                     ZoneOffset.class.getName().equals(param.className()) ||
                     LocalDate.class.getName().equals(param.className()) ||
                     Integer.class.getName().equals(param.className()) ||
                     Long.class.getName().equals(param.className()) ||
+                    Double.class.getName().equals(param.className()) ||
+                    Float.class.getName().equals(param.className()) ||
                     Boolean.class.getName().equals(param.className()) ||
                     "io.yupiik.fusion.jsonrpc.api.PartialResponse".equals(param.className()) ||
                     Object.class.getName().equals(param.className());

--- a/fusion-processor/src/main/java/io/yupiik/fusion/framework/processor/internal/generator/JsonRpcEndpointGenerator.java
+++ b/fusion-processor/src/main/java/io/yupiik/fusion/framework/processor/internal/generator/JsonRpcEndpointGenerator.java
@@ -270,6 +270,8 @@ public class JsonRpcEndpointGenerator extends BaseHttpEndpointGenerator implemen
                             new JsonSchema(null, null, "integer", !(required != null && required) && !"int".equals(type.className()), "int32", null, null, null, null);
                     case "long", "java.lang.Long" ->
                             new JsonSchema(null, null, "integer", !(required != null && required) && !"long".equals(type.className()), "int64", null, null, null, null);
+                    case "double", "float", "java.lang.Double", "java.lang.Float" ->
+                            new JsonSchema(null, null, "number", !(required != null && required) && !Character.isLowerCase(type.className().charAt(0)), null, null, null, null, null);
                     case "java.time.OffsetDateTime", "java.time.ZoneOffset" ->
                             new JsonSchema(null, null, "string", !(required != null && required), "date-time", null, null, null, null);
                     case "java.time.LocalDate" ->
@@ -310,6 +312,8 @@ public class JsonRpcEndpointGenerator extends BaseHttpEndpointGenerator implemen
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"int".equals(type.args().get(0)), "int32", null, null, null, null);
                                     case "long", "java.lang.Long" ->
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"long".equals(type.args().get(0)), "int64", null, null, null, null);
+                                    case "double", "float", "java.lang.Double", "java.lang.Float" ->
+                                            new JsonSchema(null, null, "number", !(required != null && required) && !Character.isLowerCase(type.args().get(0).charAt(0)), null, null, null, null, null);
                                     case "java.lang.String" ->
                                             new JsonSchema(null, null, "string", !(required != null && required), null, null, null, null, null);
                                     default -> {
@@ -337,6 +341,8 @@ public class JsonRpcEndpointGenerator extends BaseHttpEndpointGenerator implemen
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"int".equals(type.args().get(1)), "int32", null, null, null, null);
                                     case "long", "java.lang.Long" ->
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"long".equals(type.args().get(1)), "int64", null, null, null, null);
+                                    case "double", "float", "java.lang.Double", "java.lang.Float" ->
+                                            new JsonSchema(null, null, "number", !(required != null && required) && !Character.isLowerCase(type.args().get(1).charAt(0)), null, null, null, null, null);
                                     case "java.lang.String" ->
                                             new JsonSchema(null, null, "string", true, null, null, null, null, null);
                                     default -> {
@@ -365,6 +371,8 @@ public class JsonRpcEndpointGenerator extends BaseHttpEndpointGenerator implemen
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"int".equals(type.args().get(0)), "int32", null, null, null, null);
                                     case "long", "java.lang.Long" ->
                                             new JsonSchema(null, null, "integer", !(required != null && required) && !"long".equals(type.args().get(0)), "int64", null, null, null, null);
+                                    case "double", "float", "java.lang.Double", "java.lang.Float" ->
+                                            new JsonSchema(null, null, "number", !(required != null && required) && !Character.isLowerCase(type.args().get(0).charAt(0)), null, null, null, null, null);
                                     case "java.lang.String" ->
                                             new JsonSchema(null, null, "string", !(required != null && required), null, null, null, null, null);
                                     default -> {

--- a/fusion-processor/src/test/java/io/yupiik/fusion/framework/processor/FusionProcessorTest.java
+++ b/fusion-processor/src/test/java/io/yupiik/fusion/framework/processor/FusionProcessorTest.java
@@ -1519,6 +1519,53 @@ class FusionProcessorTest {
                 });
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void jsonRpcEnumParams(@TempDir final Path work) throws IOException {
+        new Compiler(work, "JsonRpcEnumParam")
+                .compileAndAssertsInstance((container, instance) -> {
+                    final var provider = (Supplier<String>) instance.instance();
+                    assertNull(provider.get());
+
+                    try (final var endpointInstance = container.lookup(JsonRpcEndpoint.class)) {
+                        assertJsonRpc(
+                                endpointInstance.instance(), """
+                                        {
+                                          "jsonrpc": "2.0",
+                                          "method": "param",
+                                          "params": { "par": "in" }
+                                        }
+                                        """,
+                                "",
+                                202);
+                        assertEquals("in", provider.get());
+                    }
+                });
+    }
+    @Test
+    @SuppressWarnings("unchecked")
+    void jsonRpcDoubleParams(@TempDir final Path work) throws IOException {
+        new Compiler(work, "JsonRpcDoubleParam")
+                .compileAndAssertsInstance((container, instance) -> {
+                    final var provider = (Supplier<String>) instance.instance();
+                    assertNull(provider.get());
+
+                    try (final var endpointInstance = container.lookup(JsonRpcEndpoint.class)) {
+                        assertJsonRpc(
+                                endpointInstance.instance(), """
+                                        {
+                                          "jsonrpc": "2.0",
+                                          "method": "param",
+                                          "params": { "par": 1.2, "par2": 1.2 }
+                                        }
+                                        """,
+                                "",
+                                202);
+                        assertEquals("1.2", provider.get());
+                    }
+                });
+    }
+
     @TestFactory
     Stream<DynamicTest> jsonRpc(@TempDir final Path work) throws IOException {
         final var compiler = new Compiler(work, "JsonRpcEndpoints").assertCompiles(0);

--- a/fusion-processor/src/test/resources/test/p/JsonRpcDoubleParam.java
+++ b/fusion-processor/src/test/resources/test/p/JsonRpcDoubleParam.java
@@ -13,24 +13,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.yupiik.fusion.json.internal.codec;
+package test.p;
 
-import io.yupiik.fusion.json.spi.Parser;
+import io.yupiik.fusion.framework.build.api.jsonrpc.JsonRpc;
+import io.yupiik.fusion.framework.build.api.jsonrpc.JsonRpcParam;
 
-import java.math.BigDecimal;
+import java.util.function.Supplier;
 
-public class IntegerJsonCodec extends NumberJsonCodec<Integer> {
-    public IntegerJsonCodec() {
-        super(Integer.class);
-    }
-
-    @Override
-    protected Integer read(final Parser parser) {
-        return parser.getInt();
-    }
+public class JsonRpcDoubleParam implements Supplier<String> {
+    public static String last = null;
 
     @Override
-    protected Integer mapBigDecimal(final BigDecimal bigDecimal) {
-        return bigDecimal.intValue();
+    public String get() {
+        return last;
+    }
+
+    @JsonRpc("param")
+    public void call(@JsonRpcParam final double par, @JsonRpcParam final Double par2) {
+        // just to avoid common errors with toString() over jvm versions we do not care about
+        last = par == 1.2 && par2 == 1.2 ? "1.2" : "-1";
     }
 }

--- a/fusion-processor/src/test/resources/test/p/JsonRpcEnumParam.java
+++ b/fusion-processor/src/test/resources/test/p/JsonRpcEnumParam.java
@@ -13,24 +13,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.yupiik.fusion.json.internal.codec;
+package test.p;
 
-import io.yupiik.fusion.json.spi.Parser;
+import io.yupiik.fusion.framework.build.api.json.JsonModel;
+import io.yupiik.fusion.framework.build.api.jsonrpc.JsonRpc;
+import io.yupiik.fusion.framework.build.api.jsonrpc.JsonRpcParam;
 
-import java.math.BigDecimal;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
-public class IntegerJsonCodec extends NumberJsonCodec<Integer> {
-    public IntegerJsonCodec() {
-        super(Integer.class);
-    }
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
-    @Override
-    protected Integer read(final Parser parser) {
-        return parser.getInt();
-    }
+public class JsonRpcEnumParam implements Supplier<String> {
+    public static String last = null;
 
     @Override
-    protected Integer mapBigDecimal(final BigDecimal bigDecimal) {
-        return bigDecimal.intValue();
+    public String get() {
+        return last;
+    }
+
+    @JsonRpc("param")
+    public void call(@JsonRpcParam final Par par) {
+        last = par.name();
+    }
+
+    @JsonModel
+    public enum Par {
+        in, out
     }
 }


### PR DESCRIPTION
…x) and tolerate string for numbers in json deserialization (bigdecimal round trip is weirdish)