### PR TITLE
[cli] add shell completion and selective registration via fusion.cli.shell

### DIFF
--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/BaseCompletionCliCommand.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/BaseCompletionCliCommand.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.framework.api.Instance;
+import io.yupiik.fusion.framework.api.RuntimeContainer;
+import io.yupiik.fusion.framework.api.configuration.Configuration;
+import io.yupiik.fusion.framework.api.container.bean.BaseBean;
+import io.yupiik.fusion.framework.api.scope.DefaultScoped;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Base {@link Bean} producing a {@link CliCommand} that prints a shell completion script.
+ * Subclasses set the command path/description and the script body; shared helpers for
+ * command-tree navigation and candidate computation are exposed as {@code protected} methods.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public abstract class BaseCompletionCliCommand extends BaseBean<CliCommand> {
+    protected BaseCompletionCliCommand() {
+        super(CliCommand.class, DefaultScoped.class, 1000, Map.of());
+    }
+
+    /**
+     * @return the subcommand path, e.g. {@code {completion, bash}}.
+     */
+    protected abstract String[] path();
+
+    /**
+     * @return a description telling the user how to use the generated script.
+     */
+    protected abstract String description();
+
+    /**
+     * Writes the shell-specific output to {@link System#out}.
+     *
+     * @param commands      the registered commands.
+     * @param configuration the effective configuration (app name, comp.line/comp.point cursor overrides).
+     */
+    protected abstract void write(List<CliCommand<? extends Runnable>> commands, Configuration configuration);
+
+    @Override
+    public CliCommand create(final RuntimeContainer container, final List<Instance<?>> dependents) {
+        return new BaseCliCommand<>(
+                path(), description(),
+                identity(),
+                (final Configuration conf, final List<Instance<?>> deps) -> (Runnable) () -> {
+                    // the returned Instance is added to the execution dependents so it is closed with the command
+                    final var commands = container.lookups(CliCommand.class, BaseCompletionCliCommand::toCommands);
+                    deps.add(commands);
+                    write(commands.instance(), conf);
+                },
+                List.of(),
+                Map.of());
+    }
+
+    private static List<CliCommand<? extends Runnable>> toCommands(final List<Instance<CliCommand>> instances) {
+        return instances.stream().map(BaseCompletionCliCommand::cast).toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CliCommand<? extends Runnable> cast(final Instance<CliCommand> instance) {
+        return (CliCommand<? extends Runnable>) instance.instance();
+    }
+
+    /**
+     * @return the completion function name for {@code app}.
+     */
+    protected String funcName(final String app) {
+        return "_" + app.replace('-', '_') + "_complete";
+    }
+
+    /**
+     * @return the application name used in scripts, from {@code fusion.cli.app.name} or {@code app}.
+     */
+    protected String appName(final Configuration configuration) {
+        return configuration.get("fusion.cli.app.name").orElse("app");
+    }
+
+    /**
+     * Direct child segments of {@code prefix}: the next {@code path()} segment of every command
+     * starting (but not ending) with {@code prefix}.
+     */
+    protected Stream<String> children(final List<CliCommand<? extends Runnable>> commands, final List<String> prefix) {
+        return commands.stream()
+                .flatMap(it -> {
+                    final var path = List.of(it.path());
+                    if (path.size() <= prefix.size() || !path.subList(0, prefix.size()).equals(prefix)) {
+                        return Stream.empty();
+                    }
+                    return Stream.of(path.get(prefix.size()));
+                })
+                .collect(toSet())
+                .stream();
+    }
+
+    /**
+     * @return the command whose {@code path()} is exactly {@code tokens}, or {@code null}.
+     */
+    protected CliCommand<? extends Runnable> resolved(final List<CliCommand<? extends Runnable>> commands, final List<String> tokens) {
+        for (final var command : commands) {
+            if (List.of(command.path()).equals(tokens)) {
+                return command;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Computes shell-agnostic candidates: subcommand segments while the path is incomplete,
+     * then the {@code --options} of the resolved leaf command.
+     *
+     * @param typed the words typed so far (excludes the current word being completed).
+     * @param cur   the current partial word (may be empty).
+     */
+    protected List<String> candidates(final List<CliCommand<? extends Runnable>> commands, final List<String> typed, final String cur) {
+        final var leaf = resolved(commands, typed);
+        if (leaf != null) {
+            return options(leaf, cur);
+        }
+        if (typed.isEmpty()) {
+            return startsWith(commands.stream().map(it -> it.path()[0]).distinct().sorted().toList(), cur);
+        }
+        return startsWith(children(commands, typed).sorted().toList(), cur);
+    }
+
+    private List<String> options(final CliCommand<? extends Runnable> command, final String cur) {
+        final var prefix = command.cliPrefix();
+        return startsWith(command.parameters().stream()
+                .map(p -> displayName(prefix, p.cliName()))
+                .sorted()
+                .toList(), cur);
+    }
+
+    private List<String> startsWith(final List<String> names, final String cur) {
+        return names.stream().filter(it -> it.startsWith(cur)).toList();
+    }
+
+    protected String displayName(final String cmdPrefix, final String cliName) {
+        return cliName.startsWith(cmdPrefix) ? "--" + cliName.substring(cmdPrefix.length()) : cliName;
+    }
+
+    protected String commandPath(final CliCommand<? extends Runnable> command) {
+        return String.join(" ", command.path());
+    }
+
+    /**
+     * @return the sorted option names ({@code --flag}) of a command.
+     */
+    protected List<String> optionNames(final CliCommand<? extends Runnable> command) {
+        final var prefix = command.cliPrefix();
+        return command.parameters().stream()
+                .map(p -> displayName(prefix, p.cliName()))
+                .sorted()
+                .toList();
+    }
+}

--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CliModule.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CliModule.java
@@ -18,11 +18,31 @@ package io.yupiik.fusion.cli.internal;
 import io.yupiik.fusion.framework.api.container.FusionBean;
 import io.yupiik.fusion.framework.api.container.FusionModule;
 
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 public class CliModule implements FusionModule {
     @Override
     public Stream<FusionBean<?>> beans() {
-        return Stream.of(new CliAwaiterBean());
+        return Stream.concat(
+                Stream.of(new CliAwaiterBean()),
+                resolveShells().stream().map(CliShell::newCommand));
+    }
+
+    private static List<CliShell> resolveShells() {
+        return CliShell.select(
+                resolve("fusion.cli.shell", "FUSION_CLI_SHELL"),
+                System.getenv("SHELL"),
+                isWindows());
+    }
+
+    private static String resolve(final String property, final String env) {
+        final var value = System.getProperty(property);
+        return value != null && !value.isBlank() ? value : System.getenv(env);
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
     }
 }

--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CliShell.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CliShell.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import static java.util.Locale.ROOT;
+
+/**
+ * Describes the shell(s) for which the CLI should register a completion command.
+ * <p>
+ * The effective value comes from the {@code fusion.cli.shell} configuration key (system property
+ * {@code fusion.cli.shell} or {@code FUSION_CLI_SHELL} environment variable). It accepts:
+ * <ul>
+ *     <li>{@code all} - register the completion command for every supported shell,</li>
+ *     <li>{@code none} - register no completion command,</li>
+ *     <li>{@code bash}, {@code zsh} or {@code powershell} - restrict to that shell,</li>
+ *     <li>absent - detect the current shell from the environment ({@code bash} when inconclusive).</li>
+ * </ul>
+ */
+public enum CliShell {
+    BASH("bash", CompletionBashCommand::new),
+    ZSH("zsh", CompletionZshCommand::new),
+    POWERSHELL("powershell", CompletionPowerShellCommand::new);
+
+    private final String id;
+    private final Supplier<BaseCompletionCliCommand> command;
+
+    CliShell(final String id, final Supplier<BaseCompletionCliCommand> command) {
+        this.id = id;
+        this.command = command;
+    }
+
+    /**
+     * @return the completion command bean for this shell.
+     */
+    public BaseCompletionCliCommand newCommand() {
+        return command.get();
+    }
+
+    /**
+     * Selects the shells to register.
+     *
+     * @param override the {@code fusion.cli.shell} value, already resolved from property/env (may be blank).
+     * @param shell    the {@code $SHELL} environment value (may be null).
+     * @param windows  whether the JVM is running on Windows.
+     * @return the shells to register, possibly empty.
+     */
+    public static List<CliShell> select(final String override, final String shell, final boolean windows) {
+        final var effective = override == null ? "" : override.toLowerCase(ROOT).trim();
+        switch (effective) {
+            case "all":
+                return List.of(BASH, ZSH, POWERSHELL);
+            case "none":
+                return List.of();
+            case "bash":
+            case "zsh":
+            case "powershell":
+                return List.of(byId(effective));
+            default:
+                return List.of(detect(shell, windows));
+        }
+    }
+
+    private static CliShell detect(final String shell, final boolean windows) {
+        if (shell != null) {
+            final var lower = shell.toLowerCase(ROOT);
+            if (lower.contains("zsh")) {
+                return ZSH;
+            }
+            if (lower.contains("bash") || lower.contains("sh")) {
+                return BASH;
+            }
+        }
+        return windows ? POWERSHELL : BASH;
+    }
+
+    private static CliShell byId(final String id) {
+        for (final var value : values()) {
+            if (value.id.equals(id)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported shell '" + id + "', expected one of all, none, "
+                + String.join(",", List.of(BASH.id, ZSH.id, POWERSHELL.id)));
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionBashCommand.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionBashCommand.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.framework.api.configuration.Configuration;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * {@code completion bash}: prints a bash completion script.
+ */
+public class CompletionBashCommand extends BaseCompletionCliCommand {
+    @Override
+    protected String[] path() {
+        return new String[]{"completion", "bash"};
+    }
+
+    @Override
+    protected String description() {
+        return "Print a bash completion script. " +
+                "Usage: <app> completion bash > /etc/bash_completion.d/<app> (then source it, or eval \"$(<app> completion bash)\").";
+    }
+
+    @Override
+    protected void write(final List<CliCommand<? extends Runnable>> commands, final Configuration configuration) {
+        final var line = configuration.get("comp.line").orElse(null);
+        final var point = configuration.get("comp.point").map(Integer::parseInt).orElse(null);
+        if (line == null || point == null) {
+            System.out.print(bashScript(commands, appName(configuration)));
+            return;
+        }
+        candidatesFor(line, point, commands).forEach(System.out::println);
+    }
+
+    protected String bashScript(final List<CliCommand<? extends Runnable>> commands, final String app) {
+        final var fn = funcName(app);
+        final var out = new StringBuilder();
+        out.append("# bash completion for ").append(app).append('\n');
+        out.append(fn).append("() {\n");
+        out.append("    local cur path line seg\n");
+        out.append("    COMPREPLY=()\n");
+        out.append("    cur=\"${COMP_WORDS[COMP_CWORD]}\"\n");
+        out.append("    path=\"\"\n");
+        out.append("    local i\n");
+        out.append("    for ((i=1;i<COMP_CWORD;i++)); do\n");
+        out.append("        path=\"${path}${path:+ }${COMP_WORDS[i]}\"\n");
+        out.append("    done\n");
+        out.append("    while IFS= read -r line; do\n");
+        out.append("        if [[ \"$line\" == \"$path\" ]]; then\n");
+        out.append("            COMPREPLY=( $(compgen -W \"$(").append(fn).append("_opts \"$line\")\" -- \"$cur\") )\n");
+        out.append("            return 0\n");
+        out.append("        fi\n");
+        out.append("    done < <(").append(fn).append("_cmds)\n");
+        out.append("    local out=\"\"\n");
+        out.append("    while IFS= read -r line; do\n");
+        out.append("        if [[ -z \"$path\" ]]; then seg=\"${line%% *}\";\n");
+        out.append("        elif [[ \"$line\" == \"$path \"* ]]; then seg=\"${line#$path }\"; seg=\"${seg%% *}\";\n");
+        out.append("        else continue; fi\n");
+        out.append("        [[ \"$seg\" == \"$cur\"* && \" $out \" != *\" $seg \"* ]] && out=\"$out $seg\"\n");
+        out.append("    done < <(").append(fn).append("_cmds)\n");
+        out.append("    COMPREPLY=( $(compgen -W \"$out\" -- \"$cur\") )\n");
+        out.append("    return 0\n");
+        out.append("}\n");
+        out.append(fn).append("_cmds() {\n");
+        for (final var command : commands) {
+            out.append("    printf '%s\\n' '").append(escape(commandPath(command))).append("'\n");
+        }
+        out.append("}\n");
+        out.append(fn).append("_opts() {\n");
+        out.append("    case \"$1\" in\n");
+        for (final var command : commands) {
+            out.append("        '").append(escape(commandPath(command))).append("') printf '%s\\n' ");
+            final var options = optionNames(command);
+            if (options.isEmpty()) {
+                out.append("'' ;;");
+            } else {
+                options.forEach(opt -> out.append('\'').append(escape(opt)).append("' "));
+                out.append(";;");
+            }
+            out.append('\n');
+        }
+        out.append("    esac\n");
+        out.append("}\n");
+        out.append("complete -F ").append(fn).append(' ').append(app).append('\n');
+        return out.toString();
+    }
+
+    private static String escape(final String value) {
+        return value == null ? "" : value.replace("'", "'\\''");
+    }
+
+    protected List<String> candidatesFor(final String line, final int point, final List<CliCommand<? extends Runnable>> commands) {
+        final var trimmed = line.length() < point ? line : line.substring(0, Math.max(point, 0));
+        if (!trimmed.isEmpty() && trimmed.charAt(trimmed.length() - 1) == ' ') {
+            final var prefix = trimmed.isEmpty() ? "" : trimmed.substring(0, trimmed.length() - 1);
+            return candidates(commands, splitWords(prefix), "");
+        }
+        final var sp = trimmed.lastIndexOf(' ');
+        final var cur = sp < 0 ? trimmed : trimmed.substring(sp + 1);
+        return candidates(commands, splitWords(sp < 0 ? "" : trimmed.substring(0, sp)), cur);
+    }
+
+    private static List<String> splitWords(final String text) {
+        if (text.isBlank()) {
+            return List.of();
+        }
+        return Stream.of(text.split("\\s+")).toList();
+    }
+}

--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionPowerShellCommand.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionPowerShellCommand.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.framework.api.configuration.Configuration;
+
+import java.util.List;
+
+/**
+ * {@code completion powershell}: prints a PowerShell completion script.
+ */
+public class CompletionPowerShellCommand extends BaseCompletionCliCommand {
+    @Override
+    protected String[] path() {
+        return new String[]{"completion", "powershell"};
+    }
+
+    @Override
+    protected String description() {
+        return "Print a PowerShell completion script. " +
+                "Usage: add the output to your PowerShell profile, or run \"<app> completion powershell | Out-String | Invoke-Expression\".";
+    }
+
+    @Override
+    protected void write(final List<CliCommand<? extends Runnable>> commands, final Configuration configuration) {
+        System.out.print(powershellScript(commands, appName(configuration)));
+    }
+
+    protected String powershellScript(final List<CliCommand<? extends Runnable>> commands, final String app) {
+        final var out = new StringBuilder();
+        out.append("# PowerShell completion for ").append(app).append('\n');
+        out.append("Register-ArgumentCompleter -Native -CommandName '").append(escape(app)).append("' -ScriptBlock {\n");
+        out.append("    param($wordToComplete, $commandAst, $cursorPosition)\n");
+        out.append("    $elements = @($commandAst.CommandElements | Select-Object -Skip 1)\n");
+        out.append("    $tokens = @($elements[0..($elements.Count - 2)]) -join ' '\n");
+        out.append("    $leaf = @'").append('\n');
+        for (final var command : commands) {
+            out.append("    ").append(escape(commandPath(command))).append('\n');
+        }
+        out.append("'@ -split \"`n\" | Where-Object { $_ -match '\\S' }\n");
+        out.append("    if ($tokens -in $leaf) {\n");
+        out.append("        $opts = & { switch ($tokens) {\n");
+        for (final var command : commands) {
+            if (!optionNames(command).isEmpty()) {
+                out.append("            '").append(escape(commandPath(command))).append("' { '")
+                        .append(String.join("' '", optionNames(command))).append("' }\n");
+            }
+        }
+        out.append("        } }\n");
+        out.append("        $opts | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object { ")
+                .append("[System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_) }\n");
+        out.append("    } elseif ($tokens -eq '' -and $wordToComplete) {\n");
+        out.append("        $leaf | ForEach-Object { if($_ -like \"$wordToComplete*\") { ")
+                .append("[System.Management.Automation.CompletionResult]::new(($_ -split ' ')[0], ($_ -split ' ')[0], ")
+                .append("'ParameterName', $_) } }\n");
+        out.append("    } else {\n");
+        out.append("        $prefix = if($tokens) { \"$tokens \" } else { '' }\n");
+        out.append("        $leaf | Where-Object { $_ -like \"$prefix*\" } | ForEach-Object { ")
+                .append("$rest = $_.Substring($prefix.Length); $seg = ($rest -split ' ')[0]; ")
+                .append("if($seg -like \"$wordToComplete*\") { [System.Management.Automation.CompletionResult]::new($seg, ")
+                .append("$seg, 'Command', $_) } }\n");
+        out.append("    }\n");
+        out.append("}\n");
+        return out.toString();
+    }
+
+    private static String escape(final String value) {
+        return value == null ? "" : value.replace("'", "''");
+    }
+}

--- a/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionZshCommand.java
+++ b/fusion-cli/src/main/java/io/yupiik/fusion/cli/internal/CompletionZshCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.framework.api.configuration.Configuration;
+
+import java.util.List;
+
+/**
+ * {@code completion zsh}: prints a zsh completion script.
+ */
+public class CompletionZshCommand extends BaseCompletionCliCommand {
+    @Override
+    protected String[] path() {
+        return new String[]{"completion", "zsh"};
+    }
+
+    @Override
+    protected String description() {
+        return "Print a zsh completion script. " +
+                "Usage: save the output as \"_<app>\" in a fpath directory (e.g. ~/.zfunc/_<app>) " +
+                "and add fpath+autoload -Uz compinit && compinit.";
+    }
+
+    @Override
+    protected void write(final List<CliCommand<? extends Runnable>> commands, final Configuration configuration) {
+        System.out.print(zshScript(commands, appName(configuration)));
+    }
+
+    protected String zshScript(final List<CliCommand<? extends Runnable>> commands, final String app) {
+        final var fn = "_" + app.replace('-', '_');
+        final var out = new StringBuilder();
+        out.append("#compdef ").append(app).append('\n');
+        out.append("# zsh completion for ").append(app).append('\n');
+        out.append(fn).append("() {\n");
+        out.append("    local -a cmds opts\n");
+        out.append("    local curcontext=\"$curcontext\" state line\n");
+        out.append("    typeset -A opt_args\n");
+        out.append("    cmds=(\n");
+        for (final var command : commands) {
+            out.append("        '").append(escape(commandPath(command))).append(":").append(escape(command.description())).append("'\n");
+        }
+        out.append("    )\n");
+        out.append("    _arguments -C \\\n");
+        out.append("        '1: :->command'\n");
+        out.append("        '*::arg:->args'\n");
+        out.append("    _describe 'command' cmds -Q\n");
+        out.append("    return 1\n");
+        out.append("}\n");
+        out.append("compdef ").append(fn).append(' ').append(app).append('\n');
+        return out.toString();
+    }
+
+    private static String escape(final String value) {
+        return value == null ? "" : value.replace("'", "'\\''").replace("\n", " ");
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CliCommandFixture.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CliCommandFixture.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds lightweight {@link CliCommand} fixtures for unit tests, mirroring the shape the
+ * annotation processor generates for a {@code @Command}/{@code @RootConfiguration} pair.
+ */
+public final class CliCommandFixture {
+    private CliCommandFixture() {
+        // no-op
+    }
+
+    public static List<CliCommand<? extends Runnable>> commands() {
+        return List.of(
+                command("init", "Create config + database and migrate."),
+                command("discover", "Discover new companies.", "limit", "country"),
+                command(new String[]{"scan", "all"}, "Scan all companies.", "limit", "dry-run"),
+                command(new String[]{"scan", "company"}, "Scan a company by id.", "id"),
+                command(new String[]{"scan", "fill"}, "Resolve missing websites.", "limit", "method"),
+                command(new String[]{"completion", "bash"}, "Print a bash completion script."));
+    }
+
+    private static CliCommand<? extends Runnable> command(final String command, final String description, final String... options) {
+        return command(new String[]{command}, description, options);
+    }
+
+    private static CliCommand<? extends Runnable> command(final String[] path, final String description, final String... options) {
+        final var parameters = List.of(options).stream()
+                .map(opt -> {
+                    final var cliName = opt.startsWith("--") ? opt : "--" + opt;
+                    return new CliCommand.Parameter(cliName, cliName, cliName);
+                })
+                .toList();
+        return new BaseCliCommand<>(path, description,
+                conf -> null,
+                (conf, deps) -> (Runnable) () -> {},
+                parameters,
+                Map.of());
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CliShellTest.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CliShellTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CliShellTest {
+    @Test
+    void allRegistersEveryShell() {
+        assertEquals(List.of(CliShell.BASH, CliShell.ZSH, CliShell.POWERSHELL),
+                CliShell.select("all", "/bin/bash", false));
+    }
+
+    @Test
+    void noneRegistersNothing() {
+        assertEquals(List.of(), CliShell.select("none", "/bin/bash", false));
+    }
+
+    @Test
+    void explicitShellWinsOverEnvironment() {
+        assertEquals(List.of(CliShell.ZSH), CliShell.select("zsh", "/bin/bash", false));
+        assertEquals(List.of(CliShell.POWERSHELL), CliShell.select("powershell", "/bin/bash", false));
+        assertEquals(List.of(CliShell.BASH), CliShell.select("bash", "/usr/bin/zsh", true));
+    }
+
+    @Test
+    void explicitValueIsCaseInsensitiveAndTrimmed() {
+        assertEquals(List.of(CliShell.POWERSHELL), CliShell.select("  POWERSHELL ", "/bin/bash", false));
+    }
+
+    @Test
+    void detectsZshFromShell() {
+        assertEquals(List.of(CliShell.ZSH), CliShell.select("", "/usr/bin/zsh", false));
+    }
+
+    @Test
+    void detectsBashFromShell() {
+        assertEquals(List.of(CliShell.BASH), CliShell.select("", "/bin/bash", false));
+    }
+
+    @Test
+    void defaultsToPowerShellOnWindows() {
+        assertEquals(List.of(CliShell.POWERSHELL), CliShell.select("", "", true));
+    }
+
+    @Test
+    void defaultsToBashWhenInconclusive() {
+        assertEquals(List.of(CliShell.BASH), CliShell.select("", "", false));
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionBashTest.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionBashTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.framework.api.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_OUT;
+
+@ResourceLock(SYSTEM_OUT)
+class CompletionBashTest {
+    private final CompletionBashCommand command = new CompletionBashCommand();
+    private final List<CliCommand<? extends Runnable>> commands = CliCommandFixture.commands();
+
+    @Test
+    void topLevelCandidates() {
+        assertEquals(List.of("completion", "discover", "init", "scan"),
+                command.candidatesFor("", 0, commands));
+        assertEquals(List.of("scan"), command.candidatesFor("s", 1, commands));
+    }
+
+    @Test
+    void subCommandCandidates() {
+        assertEquals(List.of("all", "company", "fill"),
+                command.candidatesFor("scan ", 5, commands));
+        assertEquals(List.of("all"), command.candidatesFor("scan a", "scan a".length(), commands));
+    }
+
+    @Test
+    void optionCandidatesAfterRootCommand() {
+        assertEquals(List.of("--dry-run", "--limit"),
+                command.candidatesFor("scan all ", "scan all ".length(), commands));
+        assertEquals(List.of("--dry-run"),
+                command.candidatesFor("scan all --d", "scan all --d".length(), commands));
+    }
+
+    @Test
+    void scriptMentionsCommandsAndOptions() {
+        final var script = command.bashScript(commands, "app");
+        assertTrue(script.contains("complete -F _app_complete app"));
+        assertTrue(script.contains("scan all"));
+        assertTrue(script.contains("--dry-run"));
+        assertTrue(script.contains("_app_complete_cmds"));
+    }
+
+    @Test
+    void descriptionsExplainUsage() {
+        assertTrue(new CompletionBashCommand().description().contains("Usage"));
+        assertTrue(new CompletionZshCommand().description().contains("Usage"));
+        assertTrue(new CompletionPowerShellCommand().description().contains("Usage"));
+    }
+
+    @Test
+    void writeRoutesToCandidatesWhenCompKeysAreSet() {
+        final var output = runWrite(Map.of("comp.line", "scan all --d", "comp.point", "12"));
+        assertTrue(output.contains("--dry-run"), output);
+        assertTrue(!output.contains("complete -F"), output);
+    }
+
+    @Test
+    void writeRoutesToScriptWithoutCompKeys() {
+        final var output = capture(() -> command.write(commands, configuration(Map.of())));
+        assertTrue(output.contains("complete -F "), output);
+    }
+
+    private String runWrite(final Map<String, String> values) {
+        return capture(() -> command.write(commands, configuration(values)));
+    }
+
+    private static Configuration configuration(final Map<String, String> values) {
+        return Configuration.of(values);
+    }
+
+    private static String capture(final Runnable runnable) {
+        final var previous = System.out;
+        final var out = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(out, true));
+            runnable.run();
+            return out.toString();
+        } finally {
+            System.setOut(previous);
+        }
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionCliTest.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionCliTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import io.yupiik.fusion.cli.CliAwaiter;
+import io.yupiik.fusion.framework.api.container.ConfiguringContainerImpl;
+import io.yupiik.fusion.framework.api.container.bean.ProvidedInstanceBean;
+import io.yupiik.fusion.framework.api.main.Args;
+import io.yupiik.fusion.framework.api.scope.DefaultScoped;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_OUT;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
+
+@ResourceLock(SYSTEM_OUT)
+@ResourceLock(SYSTEM_PROPERTIES)
+class CompletionCliTest {
+    private String run(final String shell, final List<String> args) {
+        final var previous = System.getProperty("fusion.cli.shell");
+        System.setProperty("fusion.cli.shell", shell);
+        final var out = new ByteArrayOutputStream();
+        final var previousOut = System.out;
+        try (final var container = new ConfiguringContainerImpl()
+                .register(new ProvidedInstanceBean<>(DefaultScoped.class, Args.class, () -> new Args(args)))
+                .start()) {
+            System.setOut(new PrintStream(out, true));
+            container.lookup(CliAwaiter.class).instance().await();
+            return out.toString();
+        } finally {
+            System.setOut(previousOut);
+            if (previous == null) {
+                System.clearProperty("fusion.cli.shell");
+            } else {
+                System.setProperty("fusion.cli.shell", previous);
+            }
+        }
+    }
+
+    @Test
+    void generatesBashScript() {
+        final var output = run("bash", List.of("completion", "bash"));
+        assertTrue(output.contains("_app_complete()"));
+        assertTrue(output.contains("complete -F _app_complete app"));
+        assertTrue(output.contains("_app_complete_cmds"));
+    }
+
+    @Test
+    void generatesZshScript() {
+        final var output = run("zsh", List.of("completion", "zsh"));
+        assertTrue(output.startsWith("#compdef app"));
+        assertTrue(output.contains("compdef _app app"));
+    }
+
+    @Test
+    void generatesPowerShellScript() {
+        final var output = run("powershell", List.of("completion", "powershell"));
+        assertTrue(output.contains("Register-ArgumentCompleter -Native -CommandName 'app'"));
+    }
+
+    @Test
+    void commandIsRegisteredAsACliCommand() {
+        final var output = run("bash", List.of("completion", "bash"));
+        // the completion command itself is registered, so it appears in its own command set
+        assertTrue(output.contains("completion bash"));
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionPowerShellTest.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionPowerShellTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompletionPowerShellTest {
+    @Test
+    void registersNativeCompleter() {
+        final var script = new CompletionPowerShellCommand().powershellScript(CliCommandFixture.commands(), "app");
+        assertTrue(script.contains("Register-ArgumentCompleter -Native -CommandName 'app'"));
+        assertTrue(script.contains("scan all"));
+        assertTrue(script.contains("--dry-run"));
+    }
+}

--- a/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionZshTest.java
+++ b/fusion-cli/src/test/java/io/yupiik/fusion/cli/internal/CompletionZshTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 - present - Yupiik SAS - https://www.yupiik.com
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.yupiik.fusion.cli.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompletionZshTest {
+    @Test
+    void generatesCompdef() {
+        final var script = new CompletionZshCommand().zshScript(CliCommandFixture.commands(), "app");
+        assertTrue(script.startsWith("#compdef app"));
+        assertTrue(script.contains("completion bash"));
+        assertTrue(script.contains("scan all"));
+        assertTrue(script.contains("compdef _app app"));
+    }
+}

--- a/fusion-documentation/src/main/minisite/content/fusion/cli.adoc
+++ b/fusion-documentation/src/main/minisite/content/fusion/cli.adoc
@@ -83,3 +83,24 @@ Parents are implicit dispatchers and need no `@Command` class:
 == Launching
 
 `fusion-cli` provides an integration with `Launcher` main, if you don't use it, you will have to call yourself `CLIAwaiter` and register an instance of `Args`.
+
+== Shell completion
+
+Every Fusion CLI application exposes completion commands generating shell completion scripts
+(subcommands `completion/bash`, `completion/powershell` and `completion/zsh`): they register as regular
+`CliCommand` beans, so they appear in the app usage, documentation and their own completion.
+
+Only the completion command matching the current shell is registered by default: the shell is detected from
+`$SHELL` (bash/zsh) or the OS (powershell on Windows), defaulting to `bash`. You can force the set with the
+`fusion.cli.shell` configuration key (`fusion.cli.shell` or `FUSION_CLI_SHELL`):
+`bash`, `zsh`, `powershell` to keep a single one, `all` to register every shell, or `none` to register none.
+
+* bash: `my-app completion bash > /etc/bash_completion.d/my-app` then source it, or `eval "$(my-app completion bash)"`.
+* zsh: `my-app completion zsh > ~/.zfunc/_my-app` and add `fpath+autoload -Uz compinit && compinit`.
+* powershell: `my-app completion powershell | Out-String | Invoke-Expression` or paste the output into your `$PROFILE`.
+
+The application name used in the scripts defaults to `app` and can be overridden with the
+`fusion.cli.app.name` configuration key. Completion proposes subcommand segments while the command path is
+incomplete, then the `--options` of the resolved leaf command. For testing, `completion/bash` also reads the
+`comp.line` and `comp.point` configuration keys (the `COMP_LINE`/`COMP_POINT` environment variables set by the
+shell completer) to report the candidates for an arbitrary cursor position instead of printing the script.

--- a/fusion-processor/src/test/java/io/yupiik/fusion/framework/processor/FusionProcessorTest.java
+++ b/fusion-processor/src/test/java/io/yupiik/fusion/framework/processor/FusionProcessorTest.java
@@ -54,12 +54,15 @@ import io.yupiik.fusion.persistence.api.Database;
 import io.yupiik.fusion.persistence.api.Entity;
 import io.yupiik.fusion.persistence.impl.DatabaseConfiguration;
 import io.yupiik.fusion.persistence.impl.translation.DefaultTranslation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -109,8 +112,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
+@ResourceLock(SYSTEM_PROPERTIES)
 class FusionProcessorTest {
+    @BeforeAll
+    static void pinCliShell() {
+        System.setProperty("fusion.cli.shell", "all");
+    }
+
+    @AfterAll
+    static void clearCliShell() {
+        System.clearProperty("fusion.cli.shell");
+    }
+
     @Test
     void reuseParentConstructorInSubClass(@TempDir final Path work) throws IOException {
         final var compiler = new Compiler(work, "AppScopedBeanWithoutSubClassFriendlyConstructor");
@@ -2607,7 +2622,10 @@ class FusionProcessorTest {
                         """
                                 Missing command 'unknown':
                                 Commands:
-                                  np    A command without any configuration prefix.
+                                  completion/bash          Print a bash completion script. Usage: <app> completion bash > /etc/bash_completion.d/<app> (then source it, or eval "$(<app> completion bash)").
+                                  completion/powershell    Print a PowerShell completion script. Usage: add the output to your PowerShell profile, or run "<app> completion powershell | Out-String | Invoke-Expression".
+                                  completion/zsh           Print a zsh completion script. Usage: save the output as "_<app>" in a fpath directory (e.g. ~/.zfunc/_<app>) and add fpath+autoload -Uz compinit && compinit.
+                                  np                       A command without any configuration prefix.
 
                                 Options for 'np':
                                     --name            The name.
@@ -2831,8 +2849,11 @@ class FusionProcessorTest {
                         """
                                 Missing command 'unknown':
                                 Commands:
-                                  c1    A super command.
-                                
+                                  c1                       A super command.
+                                  completion/bash          Print a bash completion script. Usage: <app> completion bash > /etc/bash_completion.d/<app> (then source it, or eval "$(<app> completion bash)").
+                                  completion/powershell    Print a PowerShell completion script. Usage: add the output to your PowerShell profile, or run "<app> completion powershell | Out-String | Invoke-Expression".
+                                  completion/zsh           Print a zsh completion script. Usage: save the output as "_<app>" in a fpath directory (e.g. ~/.zfunc/_<app>) and add fpath+autoload -Uz compinit && compinit.
+
                                 Options for 'c1':
                                     --list                    -
                                     --name                    The main "name", e.g. {"a":"b\\\\c"}.


### PR DESCRIPTION
Goal: have default completion commands

Tip: fusion.cli.shell can be hardcoded using a custom configsource and supports none/all values

Note: shell detection is really an heuristic which can be enhanced